### PR TITLE
fix the mistake of calling modbus API before T35 timer complate initi…

### DIFF
--- a/FreeModbus/modbus/include/mb_m.h
+++ b/FreeModbus/modbus/include/mb_m.h
@@ -173,6 +173,18 @@ eMBErrorCode    eMBMasterEnable( void );
 eMBErrorCode    eMBMasterDisable( void );
 
 /*! \ingroup modbus
+ * \brief Check the Modbus Master protocol stack has established or not.
+ *
+ * This function must be called and check the return value before calling
+ * any other functions.
+ *
+ * \return If the protocol stack has been established or not
+ *  TRUE.  the protocol stack has established
+ *  FALSE. the protocol stack hasn't established
+ */
+BOOL            eMBMasterIsEstablished( void );
+
+/*! \ingroup modbus
  * \brief The main pooling loop of the Modbus Master protocol stack.
  *
  * This function must be called periodically. The timer interval required

--- a/FreeModbus/modbus/mb_m.c
+++ b/FreeModbus/modbus/mb_m.c
@@ -296,8 +296,8 @@ eMBMasterPoll( void )
             break;
 
         case EV_MASTER_FRAME_RECEIVED:
-			eStatus = peMBMasterFrameReceiveCur( &ucRcvAddress, &ucMBFrame, &usLength );
-			/* Check if the frame is for us. If not ,send an error process event. */
+            eStatus = peMBMasterFrameReceiveCur( &ucRcvAddress, &ucMBFrame, &usLength );
+            /* Check if the frame is for us. If not ,send an error process event. */
             if ( ( eStatus == MB_ENOERR ) && ( ucRcvAddress == ucMBMasterGetDestAddress() ) )
             {
                 ( void ) xMBMasterPortEventPost( EV_MASTER_EXECUTE );

--- a/FreeModbus/modbus/mb_m.c
+++ b/FreeModbus/modbus/mb_m.c
@@ -71,7 +71,8 @@ static enum
 {
     STATE_ENABLED,
     STATE_DISABLED,
-    STATE_NOT_INITIALIZED
+    STATE_NOT_INITIALIZED,
+	STATE_ESTABLISHED,
 } eMBState = STATE_NOT_INITIALIZED;
 
 /* Functions pointer which are initialized in eMBInit( ). Depending on the
@@ -233,7 +234,7 @@ eMBMasterDisable( void )
 {
     eMBErrorCode    eStatus;
 
-    if( eMBState == STATE_ENABLED )
+    if(( eMBState == STATE_ENABLED ) || ( eMBState == STATE_ESTABLISHED))
     {
         pvMBMasterFrameStopCur(  );
         eMBState = STATE_DISABLED;
@@ -250,6 +251,20 @@ eMBMasterDisable( void )
     return eStatus;
 }
 
+BOOL
+eMBMasterIsEstablished( void )
+{
+    if(eMBState == STATE_ESTABLISHED)
+    {
+        return TRUE;
+    }
+    else
+    {
+        return FALSE;
+    }
+}
+
+
 eMBErrorCode
 eMBMasterPoll( void )
 {
@@ -265,7 +280,7 @@ eMBMasterPoll( void )
     eMBMasterErrorEventType errorType;
 
     /* Check if the protocol stack is ready. */
-    if( eMBState != STATE_ENABLED )
+    if(( eMBState != STATE_ENABLED ) && ( eMBState != STATE_ESTABLISHED))
     {
         return MB_EILLSTATE;
     }
@@ -277,6 +292,7 @@ eMBMasterPoll( void )
         switch ( eEvent )
         {
         case EV_MASTER_READY:
+		    eMBState = STATE_ESTABLISHED;
             break;
 
         case EV_MASTER_FRAME_RECEIVED:

--- a/FreeModbus/modbus/mb_m.c
+++ b/FreeModbus/modbus/mb_m.c
@@ -72,7 +72,7 @@ static enum
     STATE_ENABLED,
     STATE_DISABLED,
     STATE_NOT_INITIALIZED,
-	STATE_ESTABLISHED,
+    STATE_ESTABLISHED,
 } eMBState = STATE_NOT_INITIALIZED;
 
 /* Functions pointer which are initialized in eMBInit( ). Depending on the
@@ -292,22 +292,22 @@ eMBMasterPoll( void )
         switch ( eEvent )
         {
         case EV_MASTER_READY:
-		    eMBState = STATE_ESTABLISHED;
+            eMBState = STATE_ESTABLISHED;
             break;
 
         case EV_MASTER_FRAME_RECEIVED:
 			eStatus = peMBMasterFrameReceiveCur( &ucRcvAddress, &ucMBFrame, &usLength );
 			/* Check if the frame is for us. If not ,send an error process event. */
-			if ( ( eStatus == MB_ENOERR ) && ( ucRcvAddress == ucMBMasterGetDestAddress() ) )
-			{
-				( void ) xMBMasterPortEventPost( EV_MASTER_EXECUTE );
-			}
-			else
-			{
-				vMBMasterSetErrorType(EV_ERROR_RECEIVE_DATA);
-				( void ) xMBMasterPortEventPost( EV_MASTER_ERROR_PROCESS );
-			}
-			break;
+            if ( ( eStatus == MB_ENOERR ) && ( ucRcvAddress == ucMBMasterGetDestAddress() ) )
+            {
+                ( void ) xMBMasterPortEventPost( EV_MASTER_EXECUTE );
+            }
+            else
+            {
+                vMBMasterSetErrorType(EV_ERROR_RECEIVE_DATA);
+                ( void ) xMBMasterPortEventPost( EV_MASTER_ERROR_PROCESS );
+            }
+            break;
 
         case EV_MASTER_EXECUTE:
             ucFunctionCode = ucMBFrame[MB_PDU_FUNC_OFF];


### PR DESCRIPTION
在调用eMBMasterReqxxx函数前，需要等待T35定时器初始化完成，否则Modbus Poll状态机会错乱。
增加一个状态机状态STATE_ESTABLISHED。