### PR TITLE
Add default cases to prevent warnings

### DIFF
--- a/FreeModbus/modbus/mb_m.c
+++ b/FreeModbus/modbus/mb_m.c
@@ -381,8 +381,9 @@ eMBMasterPoll( void )
 			}
 			vMBMasterRunResRelease();
         	break;
+            
         default:
-        break;
+            break;
         }
 
     }

--- a/FreeModbus/modbus/mb_m.c
+++ b/FreeModbus/modbus/mb_m.c
@@ -381,7 +381,10 @@ eMBMasterPoll( void )
 			}
 			vMBMasterRunResRelease();
         	break;
+        default:
+        break;
         }
+
     }
     return MB_ENOERR;
 }

--- a/FreeModbus/modbus/rtu/mbrtu_m.c
+++ b/FreeModbus/modbus/rtu/mbrtu_m.c
@@ -341,7 +341,7 @@ xMBMasterRTUTransmitFSM( void )
         break;
 
     default:
-    break;
+        break;
     }
 
     return xNeedPoll;

--- a/FreeModbus/modbus/rtu/mbrtu_m.c
+++ b/FreeModbus/modbus/rtu/mbrtu_m.c
@@ -339,6 +339,9 @@ xMBMasterRTUTransmitFSM( void )
             }
         }
         break;
+
+    default:
+    break;
     }
 
     return xNeedPoll;


### PR DESCRIPTION
I added default cases in mb_m.c::eMBMasterPoll and mbrtu_m.c::xMBMasterRTUTransmitFSM to prevent warnings.