### PR TITLE
Update mbrtu_m.c

### DIFF
--- a/FreeModbus/modbus/rtu/mbrtu_m.c
+++ b/FreeModbus/modbus/rtu/mbrtu_m.c
@@ -204,6 +204,8 @@ eMBMasterRTUSend( UCHAR ucSlaveAddress, const UCHAR * pucFrame, USHORT usLength 
      */
     if( eRcvState == STATE_M_RX_IDLE )
     {
+        usMasterRcvBufferPos = 0;
+
         /* First byte before the Modbus-PDU is the slave address. */
         pucMasterSndBufferCur = ( UCHAR * ) pucFrame - 1;
         usMasterSndBufferCount = 1;
@@ -268,7 +270,6 @@ xMBMasterRTUReceiveFSM( void )
     	vMBMasterPortTimersDisable( );
     	eSndState = STATE_M_TX_IDLE;
 
-        usMasterRcvBufferPos = 0;
         ucMasterRTURcvBuf[usMasterRcvBufferPos++] = ucByte;
         eRcvState = STATE_M_RX_RCV;
 


### PR DESCRIPTION
Master模式下，接收缓冲区的索引在“接收到第一个字节”时重置修改为“开启发送”时重置