### PR TITLE
clear specific events before modbus master operation.

### DIFF
--- a/FreeModbus/modbus/functions/mbfunccoils_m.c
+++ b/FreeModbus/modbus/functions/mbfunccoils_m.c
@@ -94,6 +94,7 @@ eMBMasterReqReadCoils( UCHAR ucSndAddr, USHORT usCoilAddr, USHORT usNCoils ,LONG
     else if ( xMBMasterRunResTake( lTimeOut ) == FALSE ) eErrStatus = MB_MRE_MASTER_BUSY;
     else
     {
+		eMBMasterEventClear();
 		vMBMasterGetPDUSndBuf(&ucMBFrame);
 		vMBMasterSetDestAddress(ucSndAddr);
 		ucMBFrame[MB_PDU_FUNC_OFF]                 = MB_FUNC_READ_COILS;
@@ -201,6 +202,7 @@ eMBMasterReqWriteCoil( UCHAR ucSndAddr, USHORT usCoilAddr, USHORT usCoilData, LO
     else if ( xMBMasterRunResTake( lTimeOut ) == FALSE ) eErrStatus = MB_MRE_MASTER_BUSY;
     else
     {
+		eMBMasterEventClear();
 		vMBMasterGetPDUSndBuf(&ucMBFrame);
 		vMBMasterSetDestAddress(ucSndAddr);
 		ucMBFrame[MB_PDU_FUNC_OFF]                = MB_FUNC_WRITE_SINGLE_COIL;
@@ -297,6 +299,7 @@ eMBMasterReqWriteMultipleCoils( UCHAR ucSndAddr,
     else if ( xMBMasterRunResTake( lTimeOut ) == FALSE ) eErrStatus = MB_MRE_MASTER_BUSY;
     else
     {
+		eMBMasterEventClear();
 		vMBMasterGetPDUSndBuf(&ucMBFrame);
 		vMBMasterSetDestAddress(ucSndAddr);
 		ucMBFrame[MB_PDU_FUNC_OFF]                      = MB_FUNC_WRITE_MULTIPLE_COILS;

--- a/FreeModbus/modbus/functions/mbfuncdisc_m.c
+++ b/FreeModbus/modbus/functions/mbfuncdisc_m.c
@@ -79,6 +79,7 @@ eMBMasterReqReadDiscreteInputs( UCHAR ucSndAddr, USHORT usDiscreteAddr, USHORT u
     else if ( xMBMasterRunResTake( lTimeOut ) == FALSE ) eErrStatus = MB_MRE_MASTER_BUSY;
     else
     {
+		eMBMasterEventClear();
 		vMBMasterGetPDUSndBuf(&ucMBFrame);
 		vMBMasterSetDestAddress(ucSndAddr);
 		ucMBFrame[MB_PDU_FUNC_OFF]                 = MB_FUNC_READ_DISCRETE_INPUTS;

--- a/FreeModbus/modbus/functions/mbfuncholding_m.c
+++ b/FreeModbus/modbus/functions/mbfuncholding_m.c
@@ -106,6 +106,7 @@ eMBMasterReqWriteHoldingRegister( UCHAR ucSndAddr, USHORT usRegAddr, USHORT usRe
     else if ( xMBMasterRunResTake( lTimeOut ) == FALSE ) eErrStatus = MB_MRE_MASTER_BUSY;
     else
     {
+		eMBMasterEventClear();
 		vMBMasterGetPDUSndBuf(&ucMBFrame);
 		vMBMasterSetDestAddress(ucSndAddr);
 		ucMBFrame[MB_PDU_FUNC_OFF]                = MB_FUNC_WRITE_REGISTER;
@@ -177,6 +178,7 @@ eMBMasterReqWriteMultipleHoldingRegister( UCHAR ucSndAddr,
     else if ( xMBMasterRunResTake( lTimeOut ) == FALSE ) eErrStatus = MB_MRE_MASTER_BUSY;
     else
     {
+		eMBMasterEventClear();
 		vMBMasterGetPDUSndBuf(&ucMBFrame);
 		vMBMasterSetDestAddress(ucSndAddr);
 		ucMBFrame[MB_PDU_FUNC_OFF]                     = MB_FUNC_WRITE_MULTIPLE_REGISTERS;
@@ -271,6 +273,7 @@ eMBMasterReqReadHoldingRegister( UCHAR ucSndAddr, USHORT usRegAddr, USHORT usNRe
     else if ( xMBMasterRunResTake( lTimeOut ) == FALSE ) eErrStatus = MB_MRE_MASTER_BUSY;
     else
     {
+		eMBMasterEventClear();
 		vMBMasterGetPDUSndBuf(&ucMBFrame);
 		vMBMasterSetDestAddress(ucSndAddr);
 		ucMBFrame[MB_PDU_FUNC_OFF]                = MB_FUNC_READ_HOLDING_REGISTER;
@@ -366,6 +369,7 @@ eMBMasterReqReadWriteMultipleHoldingRegister( UCHAR ucSndAddr,
     else if ( xMBMasterRunResTake( lTimeOut ) == FALSE ) eErrStatus = MB_MRE_MASTER_BUSY;
     else
     {
+		eMBMasterEventClear();
 		vMBMasterGetPDUSndBuf(&ucMBFrame);
 		vMBMasterSetDestAddress(ucSndAddr);
 		ucMBFrame[MB_PDU_FUNC_OFF]                           = MB_FUNC_READWRITE_MULTIPLE_REGISTERS;

--- a/FreeModbus/modbus/functions/mbfuncinput_m.c
+++ b/FreeModbus/modbus/functions/mbfuncinput_m.c
@@ -79,6 +79,7 @@ eMBMasterReqReadInputRegister( UCHAR ucSndAddr, USHORT usRegAddr, USHORT usNRegs
     else if ( xMBMasterRunResTake( lTimeOut ) == FALSE ) eErrStatus = MB_MRE_MASTER_BUSY;
     else
     {
+		eMBMasterEventClear();
 		vMBMasterGetPDUSndBuf(&ucMBFrame);
 		vMBMasterSetDestAddress(ucSndAddr);
 		ucMBFrame[MB_PDU_FUNC_OFF]                = MB_FUNC_READ_INPUT_REGISTER;

--- a/FreeModbus/modbus/include/mb_m.h
+++ b/FreeModbus/modbus/include/mb_m.h
@@ -405,6 +405,7 @@ BOOL xMBMasterRequestIsBroadcast( void );
 eMBMasterErrorEventType eMBMasterGetErrorType( void );
 void vMBMasterSetErrorType( eMBMasterErrorEventType errorType );
 eMBMasterReqErrCode eMBMasterWaitRequestFinish( void );
+void eMBMasterEventClear( void );
 
 /* ----------------------- Callback -----------------------------------------*/
 

--- a/FreeModbus/port/rtt/portevent_m.c
+++ b/FreeModbus/port/rtt/portevent_m.c
@@ -236,4 +236,21 @@ eMBMasterReqErrCode eMBMasterWaitRequestFinish( void ) {
     return eErrStatus;
 }
 
+/**
+ * This function is used for clear all events at last modbus operation.
+ * @note If you are use OS, you can use OS's event mechanism. Otherwise you have to run
+ * much user custom delay for waiting.
+ */
+void eMBMasterEventClear( void )
+{
+    rt_uint32_t recvedEvent;
+
+    rt_event_recv(&xMasterOsEvent,
+            EV_MASTER_PROCESS_SUCESS | EV_MASTER_ERROR_RESPOND_TIMEOUT
+                    | EV_MASTER_ERROR_RECEIVE_DATA
+                    | EV_MASTER_ERROR_EXECUTE_FUNCTION,
+            RT_EVENT_FLAG_OR | RT_EVENT_FLAG_CLEAR, RT_WAITING_NO,
+            &recvedEvent);
+}
+
 #endif


### PR DESCRIPTION
Next modbus ops may failed if we received some data before operation starting.

Signed-off-by: Xia Haiqiang <xiahaiqiang@chinayuanwang.com>